### PR TITLE
Non gsm personindex

### DIFF
--- a/doc/personindex_DataDictionary_nonGSM.csv
+++ b/doc/personindex_DataDictionary_nonGSM.csv
@@ -1,0 +1,8 @@
+"Variable / Field Name","Form Name","Section Header","Field Type","Field Label","Choices, Calculations, OR Slider Labels","Field Note","Text Validation Type OR Show Slider Number","Text Validation Min","Text Validation Max",Identifier?,"Branching Logic (Show field only if...)","Required Field?","Custom Alignment","Question Number (surveys only)","Matrix Group Name","Matrix Ranking?"
+study_subject_number,person_identifiers,,text,"Target Subject Number (TSN)",,,,,,,,,,,,
+study_subject_number_verifier_value,person_identifiers,,text,"Year of Birth",,"Enter the year the patient/research subject was born",,,,y,,,,,,
+study_enroll_date,person_identifiers,,text,"Enrollment Date",,"Enter the date the subject consented into the study",date_mdy,,,,,,,,,
+study_end_date,person_identifiers,,text,"Treatment End Date",,"Enter the date the subject ended medication treatment",date_mdy,,,,,,,,,
+mrn,person_identifiers,"Electronic Medical Record Data",text,"Medical Record Number",,"Enter the number with no leading zeros",,,,y,,y,,,,
+uuid,uuid_form,,text,UUID,,"An externally-generated unique identifier",,,,,,,,,,
+study_subject_number_verifier_field,uuid_form,,text,"Study Subject Number Verifier Field",,"Set programmatically by a data-grooming script",,,,,,,,,,


### PR DESCRIPTION
For sites not using GSM to generate the subject map they still need a person index project in REDCap as the source for the EMR administrator to generate their query. Adding the NonGSM data dictionary for the person index creates a fast way to get the project started in the sites REDCap.